### PR TITLE
Add fix-format input, that defaults to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,51 @@
 # terraform-format-action
 
-GH Action to check terraform fmt, fix if needed and push commit.
+GH Action to check terraform fmt, optionally fix and push commit.
 
-If the action finds terraform formatting issues it will fix those by running terraform format, then commit and push those changes using the author of the triggering commit. Note that the pushed commit will **not** trigger a new run of this workflow (a protection in the actions system against loops).
+By default the action checks for terraform formatting problems, passing the
+check if none found or errors, failing the check if there are issues.
+
+As auto commits can be annoying and cause issues with workflow triggering
+from automatic commits, we don't fix problems by default, if you want that
+set the fix-format input to true. Then if it finds terraform formatting
+issues it will fix those by running terraform format, then commit and push
+those changes using the author of the triggering commit. Note that the pushed
+commit will **not** trigger a new run of this workflow (a protection in the
+actions system against loops).
+
+## Inputs
+
+### fix-format
+
+Defaults to false, set to true to have the action push auto commits fixing formatting errors found.
 
 ## Usage
 
-As this action may modify the workspace when fixing formatting issues it is recommended that you run it as it's own workflow job.
+As this action may modify the workspace when fixing formatting issues it is recommended that you run it as it's own workflow job. To check the format:
 
 ```yaml
+on:
+  push:
+jobs:
+  terraform-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Terraform Format Action
+        uses: fac/terraform-format-action@release/v1
+```
+
+If you want auto fixing and commits pushing you most likely want this running on branches and PR, so the final merges have good formatting but not on your main branch as auto commits may trigger other effects such as deploys. If so use you can set that up with:
+
+```yaml
+on:
+  push:
+    branches-ignore:
+    - $default-branch
 jobs:
   terraform-format:
     runs-on: ubuntu-latest
@@ -21,13 +58,6 @@ jobs:
 
       - name: Terraform Format Action
         uses: fac/terraform-format-action@release/v1
-```
-
-You most likely want this running on branches and PR, so the final merges have good formatting but not on your main branch as auto commits may trigger other effects such as deploys. If so use you can set that up with:
-
-```yaml
-on:
-  push:
-    branches-ignore:
-    - $default-branch
+        with:
+          fix-format: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,10 @@
 name: Terraform Format
 description: Checks the terraform formatting, formats if broken and pushes the changes back to the branch. 
+inputs:
+  fix-format:
+    description: "Auto fix broken formatting and push a commit"
+    default: false
+
 runs:
   using: "composite"
   steps:
@@ -16,21 +21,24 @@ runs:
         ./terraform version
       shell: bash
 
-    - name: Terraform Format
+    - name: Terraform Format Check
       shell: bash
+      env:
+        INPUT_FIX_FORMAT: ${{ inputs.fix-format }}
       run: |
         echo Checking Terraform format
         if terraform fmt -check -diff -recursive; then
           echo "Terraform is properly formatted"
           exit 0
         fi
-        echo
+        if [[ $INPUT_FIX_FORMAT != true ]]; then
+          echo Terraform format is broken, see diff for details
+          exit 10
+        fi
+
         echo "Running Terraform format"
         terraform fmt -recursive
 
-    - name: Commit and push
-      shell: bash
-      run: |
         if git diff-index --quiet HEAD --; then
             echo No changes
             exit 0
@@ -41,3 +49,6 @@ runs:
         git commit -a -m "AutoFix: Terraform format"
         git show -s | cat
         git push
+
+        # exit with error, so the fmt check for this commit fails
+        exit 10


### PR DESCRIPTION
Only fix formatting and push commits if the input fix-format is true.

Therefore by default it runs as a linter that can required to stop badly
formatted commits getting merged. Auto fixing is actually a bit annoying
for some devs and raises issues around automation following automatic
commits, that we probably don't need to address here.

Provides v2 for fac/dev-platform#34