### PR TITLE
When format is broken, output the fix command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         INPUT_FIX_FORMAT: ${{ inputs.fix-format }}
       run: |
         echo Checking Terraform format
-        if terraform fmt -check -diff -recursive; then
+        if ./terraform fmt -check -diff -recursive; then
           echo "Terraform is properly formatted"
           exit 0
         fi
@@ -41,7 +41,7 @@ runs:
         fi
 
         echo "Running Terraform format"
-        terraform fmt -recursive
+        ./terraform fmt -recursive
 
         if git diff-index --quiet HEAD --; then
             echo No changes

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,11 @@ runs:
           exit 0
         fi
         if [[ $INPUT_FIX_FORMAT != true ]]; then
-          echo Terraform format is broken, see diff for details
+          echo
+          echo Terraform format is broken, see diff for details. To fix, run:
+          echo
+          echo terraform fmt -recursive
+          echo
           exit 10
         fi
 


### PR DESCRIPTION
Fix bug causing wrong version of tf to be used.

Echo out the command to fix the formatting when the check fails. When
a user hits the details link on the PR, this is what they will see.

![Screenshot 2021-04-07 at 12 55 08](https://user-images.githubusercontent.com/193641/113862578-7d703800-97a0-11eb-9056-8695ab9fd2f2.png)

![Screenshot 2021-04-07 at 12 57 30](https://user-images.githubusercontent.com/193641/113862825-d213b300-97a0-11eb-9ea1-dea4bfb12412.png)
