### PR TITLE
Expose the ID of the autofix commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [2.4.0] - 2021-04-12
+
+- Add new output `commit-id`, which is set to the ID of the autofix commit, if one was created.
+
 ## [2.3.0] - 2021-04-12
 
 - Fix: Error message looked like the action had broken when it had in fact detected fmt errors. Changed the error message to be less confusing.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ those changes using the author of the triggering commit. Note that the pushed
 commit will **not** trigger a new run of this workflow (a protection in the
 actions system against loops).
 
+## Outputs
+
+### commit-id
+
+If you set the `fix-format` to `true`, this gets set to the ID of the commit it creates. You can test for this:
+```yaml
+  - name: Terraform Format Action
+    uses: fac/terraform-format-action@devp/v2
+    id: tf-fmt
+    with:
+      terraform-version: "0.12.30"
+      fix-format: true
+  - name: do something if we fixed formatting
+    if: steps.tf-fmt.outputs.commit-id
+    run: echo the autofix commit ID is ${{ steps.tf-fmt.outputs.commit-id}}
+```
+
 ## Inputs
 
 ### terraform-version

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   fix-format:
     description: "Auto fix broken formatting and push a commit"
     default: false
+outputs:
+  commit-id:
+    description: "The ID of the commit created when fix-format is true"
+    value: ${{ steps.tf-fmt-check.outputs.commit-id }}
 
 runs:
   using: "composite"
@@ -37,6 +41,7 @@ runs:
         ./terraform version
 
     - name: Terraform Format Check
+      id: tf-fmt-check
       shell: bash
       env:
         INPUT_FIX_FORMAT: ${{ inputs.fix-format }}
@@ -66,3 +71,4 @@ runs:
         git commit -a -m "AutoFix: Terraform format"
         git show -s | cat
         git push
+        echo ::set-output name=commit-id::$(git rev-parse HEAD)

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,3 @@ runs:
         git commit -a -m "AutoFix: Terraform format"
         git show -s | cat
         git push
-
-        # exit with error, so the fmt check for this commit fails
-        exit 10


### PR DESCRIPTION
Also, remove the exit code that flags a job as failed when we've autofixed it.