### PR TITLE
Add a check for autofixed commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [2.%.0] - 2021-04-1#
+
+- Add new input `tick-autofix-commit`, to add a passing check to the autofix commit after it's pushed.
+
 ## [2.4.0] - 2021-04-12
 
 - Add new output `commit-id`, which is set to the ID of the autofix commit, if one was created.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Set the version of terraform to install and check formatting for. Useful if ther
 
 Defaults to false, set to true to have the action push auto commits fixing formatting errors found.
 
+### tick-autofix-commit
+
+Add a check to the commit created when `fix-format` is true. Defaults to `true`. Use this when you're calling this action from a workflow that's used as a required check. Without it, the newly-created commit will not get a green check if the commit is made with the GitHub Action-supplied token (since those tokens never trigger workflow runs).
+
+Defaults to false, set to true to have the action push auto commits fixing formatting errors found.
+
 ## Usage
 
 As this action may modify the workspace when fixing formatting issues it is recommended that you run it as it's own workflow job. To check the format:

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   fix-format:
     description: "Auto fix broken formatting and push a commit"
     default: false
+  tick-autofix-commit:
+    description: "Add a successful check for the auto fix commit"
+    default: true
 outputs:
   commit-id:
     description: "The ID of the commit created when fix-format is true"
@@ -72,3 +75,15 @@ runs:
         git show -s | cat
         git push
         echo ::set-output name=commit-id::$(git rev-parse HEAD)
+      - name: Update check for new commit
+        if: steps.tf-fmt-check.outputs.commit-id && inputs.tick-autofix-commit
+        run: |
+          curl \
+            --silent \
+            --show-error \
+            --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/check-runs \
+            -d '{ "name": "'${{ github.job }}'", "head_sha": "'${{ steps.tfFmt.outputs.commit-id }}'", "status": "completed", "conclusion": "success", "output": { "title": "Autofix check", "summary": "Created from https://github.com/'${{ github.repository }}'/actions/runs/'${{ github.run_id }}'" } }'


### PR DESCRIPTION
The autofix commit will be created with the creds from the Actions runner; those commits won't trigger workflow runs, so the new commit never gets a green tick from whatever workflow was calling the action. This change adds an explicit check to the newly-created tick, linking back to the original run.